### PR TITLE
feat: replica connection

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -7,6 +7,7 @@ require (
 	cloud.google.com/go/datastore v1.1.0
 	github.com/Masterminds/semver/v3 v3.1.1
 	github.com/brianvoe/gofakeit v3.18.0+incompatible
+	github.com/bxcodec/dbresolver v1.1.0
 	github.com/casbin/casbin/v2 v2.51.0
 	github.com/go-sql-driver/mysql v1.6.0
 	github.com/google/uuid v1.3.0

--- a/go.sum
+++ b/go.sum
@@ -70,6 +70,8 @@ github.com/OneOfOne/xxhash v1.2.2/go.mod h1:HSdplMjZKSmBqAxg5vPj2TmRDmfkzw+cTzAE
 github.com/antihax/optional v1.0.0/go.mod h1:uupD/76wgC+ih3iEmQUL+0Ugr19nfwCT1kdvxnR2qWY=
 github.com/brianvoe/gofakeit v3.18.0+incompatible h1:wDOmHc9DLG4nRjUVVaxA+CEglKOW72Y5+4WNxUIkjM8=
 github.com/brianvoe/gofakeit v3.18.0+incompatible/go.mod h1:kfwdRA90vvNhPutZWfH7WPaDzUjz+CZFqG+rPkOjGOc=
+github.com/bxcodec/dbresolver v1.1.0 h1:pzOpX6DJbO88/r6ahYrWA6rNZWr11XY4fhFcO+NEeh0=
+github.com/bxcodec/dbresolver v1.1.0/go.mod h1:XFjH6PbFCct97yML1XdBWWs1WNQILUDWAFzYg2TJtL8=
 github.com/casbin/casbin/v2 v2.51.0 h1:BC41imD9Z2coIJpELapy2h5kMT+lB4vFDTYpMhTsU4A=
 github.com/casbin/casbin/v2 v2.51.0/go.mod h1:vByNa/Fchek0KZUgG5wEsl7iFsiviAYKRtgrQfcJqHg=
 github.com/census-instrumentation/opencensus-proto v0.2.1/go.mod h1:f6KPmirojxKA12rnyqOA5BBL4O983OfeGPqjHWSTneU=
@@ -213,6 +215,10 @@ github.com/kr/pretty v0.1.0/go.mod h1:dAy3ld7l9f0ibDNOQOHHMYYIIbhfbHSm3C4ZsoJORN
 github.com/kr/pty v1.1.1/go.mod h1:pFQYn66WHrOpPYNljwOMqo10TkYh1fy3cYio2l3bCsQ=
 github.com/kr/text v0.1.0 h1:45sCR5RtlFHMR4UwH9sdQ5TC8v0qDQCHnXt+kaKSTVE=
 github.com/kr/text v0.1.0/go.mod h1:4Jbv+DJW3UT/LiOwJeYQe1efqtUx/iVham/4vfdArNI=
+github.com/lib/pq v1.10.6 h1:jbk+ZieJ0D7EVGJYpL9QTz7/YW6UHbmdnZWYyK5cdBs=
+github.com/lib/pq v1.10.6/go.mod h1:AlVN5x4E4T544tWzH6hKfbfQvm3HdbOxrmggDNAPY9o=
+github.com/mattn/go-sqlite3 v1.14.14 h1:qZgc/Rwetq+MtyE18WhzjokPD93dNqLGNT3QJuLvBGw=
+github.com/mattn/go-sqlite3 v1.14.14/go.mod h1:NyWgC/yNuGj7Q9rpYnZvas74GogHl5/Z4A/KQRfk6bU=
 github.com/montanaflynn/stats v0.0.0-20171201202039-1bf9dbcd8cbe h1:iruDEfMl2E6fbMZ9s0scYfZQ84/6SPL6zC8ACM2oIL0=
 github.com/montanaflynn/stats v0.0.0-20171201202039-1bf9dbcd8cbe/go.mod h1:wL8QJuTMNUDYhXwkmfOly8iTdp5TEcJFWZD2D7SIkUc=
 github.com/opentracing/opentracing-go v1.2.0 h1:uEJPy/1a5RIPAJ0Ov+OIO8OxWu77jEv+1B0VhjKrZUs=

--- a/sqlike/client.go
+++ b/sqlike/client.go
@@ -171,9 +171,7 @@ func (c *Client) Database(name string, connections ...*options.ConnectOptions) *
 			panic(err)
 		}
 
-		if _, err := driver.Execute(context.Background(), db, stmt, c.logger); err != nil {
-			panic(err)
-		}
+		driver.Execute(context.Background(), db, stmt, c.logger)
 		replicas[idx+1] = db
 	}
 

--- a/sqlike/client.go
+++ b/sqlike/client.go
@@ -13,6 +13,8 @@ import (
 	"github.com/RevenueMonster/sqlike/sql/driver"
 	sqlstmt "github.com/RevenueMonster/sqlike/sql/stmt"
 	"github.com/RevenueMonster/sqlike/sqlike/logs"
+	"github.com/RevenueMonster/sqlike/sqlike/options"
+	"github.com/bxcodec/dbresolver"
 )
 
 // DriverInfo :
@@ -137,23 +139,56 @@ func (c *Client) ListDatabases(ctx context.Context) ([]string, error) {
 }
 
 // Database : this api will execute `USE database`, which will point your current connection to selected database
-func (c *Client) Database(name string) *Database {
+func (c *Client) Database(name string, connections ...*options.ConnectOptions) *Database {
 	stmt := sqlstmt.AcquireStmt(c.dialect)
 	defer sqlstmt.ReleaseStmt(stmt)
 	c.dialect.UseDatabase(stmt, name)
 	if _, err := driver.Execute(context.Background(), c.DB, stmt, c.logger); err != nil {
 		panic(err)
 	}
+
+	if len(connections) == 0 {
+		return &Database{
+			driverName: c.driverName,
+			name:       name,
+			pk:         c.pk,
+			client:     c,
+			dialect:    c.dialect,
+			driver:     c.DB,
+			logger:     c.logger,
+			codec:      c.codec,
+		}
+	}
+
+	replicas := make([]*sql.DB, len(connections)+1)
+	replicas[0] = c.DB
+
+	dialect := dialect.GetDialectByDriver(c.driverName)
+	for idx, connection := range connections {
+		connStr := dialect.Connect(connection)
+		db, err := sql.Open(c.driverName, connStr)
+		if err != nil {
+			panic(err)
+		}
+
+		if _, err := driver.Execute(context.Background(), db, stmt, c.logger); err != nil {
+			panic(err)
+		}
+		replicas[idx+1] = db
+	}
+
+	resolver := dbresolver.WrapDBs(replicas...)
 	return &Database{
 		driverName: c.driverName,
 		name:       name,
 		pk:         c.pk,
 		client:     c,
 		dialect:    c.dialect,
-		driver:     c.DB,
+		driver:     resolver,
 		logger:     c.logger,
 		codec:      c.codec,
 	}
+
 }
 
 // getVersion is a internal function to get sql driver's version


### PR DESCRIPTION
# Feature
Allow to add multiple replicas such as readonly, secondary replica and resolve using round-robin strategy.

# Changes
[+] Example of Replica Connection
[+] Added new varadic paramters to `Database` function, for supporting readonly replica connection
[+] Added `dbresolver` library to support replica connection resolving